### PR TITLE
auto-admin: more changes for aarch64

### DIFF
--- a/Scripts/auto-detect-laptops
+++ b/Scripts/auto-detect-laptops
@@ -10,7 +10,7 @@ pause()
 
 case $(auto-ostype) in
 FreeBSD)
-    if dmidecode | grep -iq macbook; then
+    if dmidecode 2> /dev/null | grep -iq macbook; then
 	printf "$0: MacBook\n"
 	# https://wiki.freebsd.org/AppleMacbook
 	auto-set-conf-var atp_load '"YES"' /boot/loader.conf $0
@@ -66,9 +66,9 @@ Section "InputClass"
 EndSection
 EOM
 	chmod 644 /etc/X11/xorg.conf.d/macbook-xkb.conf
-    elif dmidecode | grep -iq thinkpad; then
+    elif dmidecode 2> /dev/null | grep -iq thinkpad; then
 	printf "$0: IBM/Lenovo ThinkPad\n"
-    elif dmidecode | grep -iq "Product name: Satellite"; then
+    elif dmidecode 2> /dev/null | grep -iq "Product name: Satellite"; then
 	printf "$0: Toshiba Satellite\n"
     fi
     ;;

--- a/Scripts/auto-ports-checkout
+++ b/Scripts/auto-ports-checkout
@@ -22,6 +22,9 @@ usage()
 
 : ${PORTSDIR:=/usr/ports}
 export PORTSDIR
+if [ -e $PORTSDIR ]; then
+    mkdir -p $PORTSDIR || exit 1
+fi
 
 case $(auto-ostype) in
 FreeBSD)

--- a/Scripts/auto-set-lid-switch-mode
+++ b/Scripts/auto-set-lid-switch-mode
@@ -16,6 +16,11 @@ EOM
 	exit 1
     fi
 
+    if [ -z "$(sysctl hw.acpi 2> /dev/null || true)" ]; then
+	printf "$0: ACPI not supported on this architecture.\n"
+	exit 1
+    fi
+
     case $1 in
     suspend)
 	state=S3

--- a/Scripts/auto-set-lid-switch-mode
+++ b/Scripts/auto-set-lid-switch-mode
@@ -1,4 +1,9 @@
 #!/bin/sh -e
+
+if [ -z "$(sysctl hw.acpi 2> /dev/null || true)" ]; then
+    printf "$0: ACPI not supported on this architecture.\n"
+    exit 1
+fi
     
 case $(auto-ostype) in
 FreeBSD)
@@ -13,11 +18,6 @@ FreeBSD)
     Run "man acpi" for more information.
     
 EOM
-	exit 1
-    fi
-
-    if [ -z "$(sysctl hw.acpi 2> /dev/null || true)" ]; then
-	printf "$0: ACPI not supported on this architecture.\n"
 	exit 1
     fi
 


### PR DESCRIPTION
ACPI sysctls and dmidecode are not available on all architectures.  Guard against annoying error messages.