### PR TITLE
auto-sound-driver-setup: actually detect snd_*.ko

### DIFF
--- a/Scripts/auto-sound-driver-setup
+++ b/Scripts/auto-sound-driver-setup
@@ -69,7 +69,7 @@ EOM
 	driver=`basename ${module%%.ko}`
 	case $driver in
 	snd_driver)
-	    break;;
+	    ;;
 	*)
 	    printf "Testing $driver...\n"
 	    if kldload ${driver} > /dev/null 2>&1; then


### PR DESCRIPTION
The 'break' statement makes testing sound devices stop once snd_driver is found, thus missing snd_[e-z]*.ko:

Testing snd_ad1816...
Testing snd_als4000...
Testing snd_atiixp...
Testing snd_cs4281...
Testing snd_csa...
Warning: No sound devices detected.

With the 'break' removed and just the ';;' left, all the devices are tested.