### PR TITLE
auto-install-base-components: Correct logic for snapshots/releases URLs

### DIFF
--- a/Scripts/auto-install-base-components
+++ b/Scripts/auto-install-base-components
@@ -79,10 +79,10 @@ FreeBSD)
 	    printf "$dist already installed.\n"
 	else
 	    cd /
-	    if `uname -r` | fgrep -q RELEASE; then
-		url=ftp://ftp.freebsd.org/pub/`uname -s`/releases/`uname -m`/`uname -r | cut -d'-' -f1,2`/$dist.txz
-	    else
+	    if `uname -r` | grep -q RELEASE; then
 		url=ftp://ftp.freebsd.org/pub/`uname -s`/snapshots/`uname -m`/`uname -r | cut -d'-' -f1,2`/$dist.txz
+	    else
+		url=ftp://ftp.freebsd.org/pub/`uname -s`/releases/`uname -m`/`uname -r | cut -d'-' -f1,2`/$dist.txz
 	    fi
 	    printf "Fetching $url...\n"
 	    fetch $url


### PR DESCRIPTION
Fixes #6.