### PR TITLE
fix: Corrected quarter calculation and removed zero padding of months in auto-pkg-branch

### DIFF
--- a/User-scripts/auto-pkg-branch
+++ b/User-scripts/auto-pkg-branch
@@ -46,8 +46,14 @@ FreeBSD)
 	# Determine latest branch that *should* exist based on today's date
 	year=$(date +%Y)                # E.g. 2024
 	month=$(date +%-m)              # E.g. 11
-	quarter=$(($month / 3 + 1))     # 11 / 3 + 1 = 4
-	branch=${year}Q$quarter         # 2024Q4
+	if [ $(($month-($month / 3) * 3)) == 0 ];
+	then
+		roundup=0
+	else
+		roundup=1
+	fi
+	quarter=$(($month / 3 + $roundup))     # 11 / 3 + 1 = 4
+	branch=${year}Q$quarter                # 2024Q4
 	
 	# Branch may not happen immediately at midnight of Jan, April,
 	# Jul, Oct 1, so check for existence of the ports branch and

--- a/User-scripts/auto-pkg-branch
+++ b/User-scripts/auto-pkg-branch
@@ -45,7 +45,7 @@ FreeBSD)
 	
 	# Determine latest branch that *should* exist based on today's date
 	year=$(date +%Y)                # E.g. 2024
-	month=$(date +%m)               # E.g. 11
+	month=$(date +%-m)              # E.g. 11
 	quarter=$(($month / 3 + 1))     # 11 / 3 + 1 = 4
 	branch=${year}Q$quarter         # 2024Q4
 	


### PR DESCRIPTION
## What?
I removed the default zero padding applied to month numbers after extraction from a date.

## Why?
The zero padding caused the quarter calculation to fail at the integer division.  See Issue #21 for more information.

## What?
I added an `if` statement to determine if `1` needed to be added to the quarter calculation or not.  I also adjusted the quarter calculation to not always add a `1`.

## Why?
The current quarter calculation, which always adds a `1`, would output a quarter number too high for month numbers evenly divisible by three.  See Issue #22 for more information.

## Testing?
Tested the `auto-pkg-branch` script in a clean FreeBSD jail and in Ubuntu 24.04 with Bash.